### PR TITLE
fix(frontend): handle redirect auth result

### DIFF
--- a/client/src/contexts/auth-context.tsx
+++ b/client/src/contexts/auth-context.tsx
@@ -92,6 +92,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     handleRedirectResult()
       .then((result) => {
         if (result) {
+          setUser(result.user);
         }
       })
       .catch((error) => {

--- a/client/src/lib/firebase.ts
+++ b/client/src/lib/firebase.ts
@@ -106,12 +106,9 @@ export const handleRedirectResult = async (): Promise<UserCredential | null> => 
   if (!firebaseAuth) {
     return null;
   }
-  
+
   try {
-    const result = await getRedirectResult(firebaseAuth);
-    if (result) {
-    }
-    return result;
+    return await getRedirectResult(firebaseAuth);
   } catch (error) {
     console.error('Redirect result handling failed:', error);
     throw error;

--- a/tests/unit/auth-context.test.tsx
+++ b/tests/unit/auth-context.test.tsx
@@ -164,13 +164,13 @@ describe('AuthContext', () => {
 
   it('should handle auth state changes', async () => {
     const mockUser = { uid: 'test-uid', email: 'test@example.com' };
-    
+
     mockOnAuthStateChange.mockImplementation((callback) => {
       // Simulate user sign in
       setTimeout(() => callback(mockUser), 0);
       return vi.fn();
     });
-    
+
     render(
       <AuthProvider>
         <TestComponent />
@@ -179,6 +179,26 @@ describe('AuthContext', () => {
 
     await waitFor(() => {
       expect(screen.getByText('user: test@example.com')).toBeInTheDocument();
+    });
+  });
+
+  it('should set user from redirect result', async () => {
+    const mockUser = { uid: 'redirect-uid', email: 'redirect@example.com' };
+
+    mockHandleRedirectResult.mockResolvedValue({ user: mockUser });
+    mockOnAuthStateChange.mockImplementation((callback) => {
+      setTimeout(() => callback(mockUser), 0);
+      return vi.fn();
+    });
+
+    render(
+      <AuthProvider>
+        <TestComponent />
+      </AuthProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('user: redirect@example.com')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- set user from redirect result to fix missing auth state after redirect login
- simplify Firebase redirect handler
- cover redirect handling with unit test

## Testing
- `npx tsc --noEmit`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68c837a96394832fa0f680bd01539300