### PR TITLE
fix: restore user profile creation endpoint

### DIFF
--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -1,4 +1,5 @@
 import { Request, Response, Router } from 'express';
+import { z } from 'zod';
 import { generateIncidentId, createUserError } from '../utils/incident';
 import { USER_ERROR_MESSAGES, HTTP_STATUS } from '../constants';
 import { logger } from '../logger';
@@ -13,7 +14,7 @@ const router = Router();
  */
 router.get('/profile', requireAuthMiddleware, async (req: Request, res: Response) => {
   const incidentId = generateIncidentId();
-  
+
   try {
     logger.info('Fetching user profile', {
       additionalContext: {
@@ -90,6 +91,120 @@ router.get('/profile', requireAuthMiddleware, async (req: Request, res: Response
       }
     );
     
+    res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR)
+      .json(createUserError(USER_ERROR_MESSAGES.SERVER_ERROR, incidentId, HTTP_STATUS.INTERNAL_SERVER_ERROR));
+  }
+});
+
+const createUserSchema = z.object({
+  userId: z.string().min(1, 'User ID is required'),
+  email: z.string().email('A valid email address is required'),
+  role: z.enum(['user', 'admin', 'super_admin']).optional()
+});
+
+/**
+ * Create a new user profile if one does not already exist
+ */
+router.post('/', requireAuthMiddleware, async (req: Request, res: Response) => {
+  const incidentId = generateIncidentId();
+
+  try {
+    const payload = createUserSchema.parse(req.body);
+
+    if (req.userId !== payload.userId) {
+      logger.warn('User ID mismatch during profile creation attempt', {
+        additionalContext: {
+          operation: 'create_user_id_mismatch',
+          authenticatedUserId: req.userId,
+          requestedUserId: payload.userId,
+          incidentId
+        }
+      });
+
+      res.status(HTTP_STATUS.FORBIDDEN)
+        .json(createUserError('You are not authorized to create this user profile.', incidentId, HTTP_STATUS.FORBIDDEN));
+      return;
+    }
+
+    if (req.userEmail && req.userEmail.toLowerCase() !== payload.email.toLowerCase()) {
+      logger.warn('Email mismatch during profile creation attempt', {
+        additionalContext: {
+          operation: 'create_user_email_mismatch',
+          userId: req.userId,
+          tokenEmail: req.userEmail,
+          payloadEmail: payload.email,
+          incidentId
+        }
+      });
+
+      res.status(HTTP_STATUS.BAD_REQUEST)
+        .json(createUserError('Email address mismatch. Please sign in again.', incidentId, HTTP_STATUS.BAD_REQUEST));
+      return;
+    }
+
+    const existingUser = await withDatabaseErrorHandling(
+      'get_user_database',
+      () => storage.getUser(payload.userId)
+    );
+
+    if (existingUser) {
+      logger.info('User profile already exists - returning existing profile', {
+        additionalContext: {
+          operation: 'create_user_existing_profile',
+          userId: payload.userId,
+          incidentId
+        }
+      });
+
+      res.json(existingUser);
+      return;
+    }
+
+    const user = await withDatabaseErrorHandling(
+      'create_user_database',
+      () => storage.createUser({
+        userId: payload.userId,
+        email: payload.email,
+        role: payload.role ?? 'user'
+      })
+    );
+
+    logger.info('User profile created successfully', {
+      additionalContext: {
+        operation: 'create_user_success',
+        userId: payload.userId,
+        incidentId
+      }
+    });
+
+    res.status(HTTP_STATUS.CREATED).json(user);
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      logger.warn('Invalid data provided while creating user profile', {
+        additionalContext: {
+          operation: 'create_user_validation_error',
+          incidentId,
+          issues: error.issues
+        }
+      });
+
+      res.status(HTTP_STATUS.BAD_REQUEST)
+        .json(createUserError(USER_ERROR_MESSAGES.VALIDATION_ERROR, incidentId, HTTP_STATUS.BAD_REQUEST));
+      return;
+    }
+
+    logger.error(
+      'Failed to create user profile',
+      error instanceof Error ? error : new Error(String(error)),
+      {
+        additionalContext: {
+          operation: 'create_user_error',
+          userId: req.userId,
+          incidentId
+        }
+      }
+    );
+
     res.status(HTTP_STATUS.INTERNAL_SERVER_ERROR)
       .json(createUserError(USER_ERROR_MESSAGES.SERVER_ERROR, incidentId, HTTP_STATUS.INTERNAL_SERVER_ERROR));
   }


### PR DESCRIPTION
## Summary
- add a POST /api/users endpoint so authenticated sign-ins can create their profile record
- validate payloads, guard against mismatched identities, and return the existing profile when one is already present
- reuse existing database helpers to persist the new user and emit structured logging

## Testing
- npm run check *(fails: pre-existing type errors in admin dashboard analytics and storage typings)*

------
https://chatgpt.com/codex/tasks/task_e_68dac1b6f390832faed5b209edf56fea